### PR TITLE
std::exception ctor doesn't accept a string.

### DIFF
--- a/Solution.cpp
+++ b/Solution.cpp
@@ -1,4 +1,4 @@
-#include <exception>
+#include <stdexcept>
 
 template <typename T> void Process(const T& t) {}
 
@@ -6,7 +6,7 @@ struct VoidParam {};
 
 inline void Process(const VoidParam&) 
 {
-    throw std::exception("'void' parameter is not allowed");
+    throw std::invalid_argument("'void' parameter is not allowed");
 }
 
 template <typename T>


### PR DESCRIPTION
No `std::exception` constructor accepts a string argument.
The solution doesn't compile.